### PR TITLE
Creating Entry Form

### DIFF
--- a/api/vocabData.js
+++ b/api/vocabData.js
@@ -27,7 +27,21 @@ const postVocab = (payload) => new Promise((resolve, reject) => {
     .catch(reject);
 });
 
+const patchVocab = (payload) => new Promise((resolve, reject) => {
+  fetch(`${endpoint}/vocab/${payload.firebaseKey}.json`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(payload)
+  })
+    .then((response) => response.json())
+    .then((data) => resolve(data))
+    .catch(reject);
+});
+
 export {
   getVocab,
-  postVocab
+  postVocab,
+  patchVocab
 };

--- a/api/vocabData.js
+++ b/api/vocabData.js
@@ -14,4 +14,20 @@ const getVocab = (user) => new Promise((resolve, reject) => {
     .catch(reject);
 });
 
-export default getVocab;
+const postVocab = (payload) => new Promise((resolve, reject) => {
+  fetch(`${endpoint}/vocab.json`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  })
+    .then((response) => response.json())
+    .then((data) => resolve(data))
+    .catch(reject);
+});
+
+export {
+  getVocab,
+  postVocab
+};

--- a/components/forms/entryForm.js
+++ b/components/forms/entryForm.js
@@ -1,0 +1,25 @@
+import renderToDom from '../../utils/renderToDom';
+import clearDom from '../../utils/clearDom';
+
+const entryForm = (obj = {}) => {
+  clearDom();
+  const domString = `<div id="entryForm">
+<form id="${obj.firebaseKey ? `entry-form--${obj.firebaseKey}` : 'submit-author'}" class="mb-4">
+<div class="form-group">
+      <label for="image">First Name</label>
+      <input type="text" class="form-control" id="first_name" placeholder="First Name" value="${obj.first_name || ''}"required>
+    </div>
+    <div class="form-group">
+      <label for="image">Last Name</label>
+      <input type="text" class="form-control" id="last_name" placeholder="Last Name" value="${obj.last_name || ''}" required>
+    </div>
+    <div class="form-group">
+      <label for="title">Email</label>
+      <input type="email" class="form-control" id="email" aria-describedby="Email" placeholder="Enter Email" value="${obj.email || ''}" required>
+    </div>
+    <button type="submit" class="btn btn-primary mt-3">Submit Author</button>
+  </form></div>`;
+  renderToDom('#entryForm', domString);
+};
+
+export default entryForm;

--- a/components/forms/entryForm.js
+++ b/components/forms/entryForm.js
@@ -19,7 +19,7 @@ const entryForm = (obj = {}) => {
     </div>
     <button type="submit" class="btn btn-primary mt-3">Submit Author</button>
   </form></div>`;
-  renderToDom('#entryForm', domString);
+  renderToDom('#main-content', domString);
 };
 
 export default entryForm;

--- a/components/forms/entryForm.js
+++ b/components/forms/entryForm.js
@@ -4,7 +4,7 @@ import clearDom from '../../utils/clearDom';
 const entryForm = (obj = {}) => {
   clearDom();
   const domString = `<div id="entryForm">
-<form id="${obj.firebaseKey ? `entry-form--${obj.firebaseKey}` : 'submit-entry'}" class="mb-4" style="height:100%;width:80%;margin-top:10%">
+<form id="${obj.firebaseKey ? `edit-entry-form--${obj.firebaseKey}` : 'submit-entry'}" class="mb-4" style="height:100%;width:80%;margin-top:10%">
 <div class="form-group">
       <label for="image">Title</label>
       <input type="text" class="form-control" id="title" placeholder="Title" value="${obj.title || ''}"required>

--- a/components/forms/entryForm.js
+++ b/components/forms/entryForm.js
@@ -4,22 +4,46 @@ import clearDom from '../../utils/clearDom';
 const entryForm = (obj = {}) => {
   clearDom();
   const domString = `<div id="entryForm">
-<form id="${obj.firebaseKey ? `entry-form--${obj.firebaseKey}` : 'submit-author'}" class="mb-4">
+<form id="${obj.firebaseKey ? `entry-form--${obj.firebaseKey}` : 'submit-entry'}" class="mb-4" style="height:100%;width:80%;margin-top:10%">
 <div class="form-group">
-      <label for="image">First Name</label>
-      <input type="text" class="form-control" id="first_name" placeholder="First Name" value="${obj.first_name || ''}"required>
+      <label for="image">Title</label>
+      <input type="text" class="form-control" id="title" placeholder="Title" value="${obj.title || ''}"required>
     </div>
     <div class="form-group">
-      <label for="image">Last Name</label>
-      <input type="text" class="form-control" id="last_name" placeholder="Last Name" value="${obj.last_name || ''}" required>
+      <label for="image">Definition</label>
+      <input type="text" class="form-control" id="definition" placeholder="Definition" value="${obj.definition || ''}" required>
     </div>
-    <div class="form-group">
-      <label for="title">Email</label>
-      <input type="email" class="form-control" id="email" aria-describedby="Email" placeholder="Enter Email" value="${obj.email || ''}" required>
-    </div>
-    <button type="submit" class="btn btn-primary mt-3">Submit Author</button>
+    <div class="dropdown" style="margin:0.5rem 0;">
+    <button class="btn btn-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false" id="category-label">
+      ${obj.category || 'Category'}
+    </button>
+    <ul class="dropdown-menu">
+      <li><a class="dropdown-item" href="#" value="Javascript" id="javascript">JavaScript</a></li>
+      <li><a class="dropdown-item" href="#" value="Cybersecurity" id="cybersecurity">Cybersecurity</a></li>
+      <li><a class="dropdown-item" href="#" value="Penetration Testing" id="pentesting">Penetration Testing</a></li>
+    </ul>
+  </div>
+    <button type="submit" class="btn btn-primary mt-3">Create Entry</button>
   </form></div>`;
   renderToDom('#main-content', domString);
+
+  // EVENT LISTENERS //
+  const eventListeners = () => {
+    document.querySelector('#entryForm').addEventListener('click', (e) => {
+      const catLabel = document.querySelector('#category-label');
+      if (e.target.id === 'javascript') {
+        catLabel.innerHTML = 'JavaScript';
+      }
+      if (e.target.id === 'cybersecurity') {
+        catLabel.innerHTML = 'Cybersecurity';
+      }
+      if (e.target.id === 'pentesting') {
+        catLabel.innerHTML = 'Penetration Testing';
+      }
+    });
+  };
+
+  eventListeners();
 };
 
 export default entryForm;

--- a/components/shared/navbar.js
+++ b/components/shared/navbar.js
@@ -6,8 +6,8 @@ const navBar = () => {
 <li class="logo">
 <i class="fa-solid fa-pen-fancy fa-3x" id="home" style="margin-bottom:auto;"></i></a>
 </li>
-  <li class="nav_item"> <a href="#" id="create-entry">
-  <i class="fa-solid fa-book fa-3x"></i>
+  <li class="nav_item"> <a href="#">
+  <i class="fa-solid fa-book fa-3x" id="create-entry"></i>
   <span class="link-text"> CREATE ENTRY </span>
   </a>
   </li>

--- a/events/formEvents.js
+++ b/events/formEvents.js
@@ -1,4 +1,5 @@
-import { postVocab } from '../api/vocabData';
+import { getVocab, postVocab, patchVocab } from '../api/vocabData';
+import showVocabCards from '../pages/vocab';
 
 const formEvents = (user) => {
   document.querySelector('#main-content').addEventListener('submit', (e) => {
@@ -10,9 +11,15 @@ const formEvents = (user) => {
         definition: document.querySelector('#definition').value,
         date: new Date(),
         category: document.querySelector('#category-label').innerHTML,
-        user: user.uid
+        uid: user.uid
       };
-      postVocab(payload).then(console.warn);
+      postVocab(payload).then(({ name }) => {
+        const patchPayload = { firebaseKey: name };
+
+        patchVocab(patchPayload).then(() => {
+          getVocab(user).then(showVocabCards);
+        });
+      });
     }
   });
 };

--- a/events/formEvents.js
+++ b/events/formEvents.js
@@ -1,0 +1,20 @@
+import { postVocab } from '../api/vocabData';
+
+const formEvents = (user) => {
+  document.querySelector('#main-content').addEventListener('submit', (e) => {
+    e.preventDefault();
+
+    if (e.target.id.includes('submit-entry')) {
+      const payload = {
+        title: document.querySelector('#title').value,
+        definition: document.querySelector('#definition').value,
+        date: new Date(),
+        category: document.querySelector('#category-label').innerHTML,
+        user: user.uid
+      };
+      postVocab(payload).then(console.warn);
+    }
+  });
+};
+
+export default formEvents;

--- a/events/navigationEvents.js
+++ b/events/navigationEvents.js
@@ -1,7 +1,7 @@
 import { signOut } from '../utils/auth';
-import getVocab from '../api/vocabData';
-import showVocabCards from '../pages/vocab';
+import { getVocab } from '../api/vocabData';
 import entryForm from '../components/forms/entryForm';
+import showVocabCards from '../pages/vocab';
 
 const navigationEvents = (user) => {
   document.querySelector('#app').addEventListener('click', (e) => {

--- a/events/navigationEvents.js
+++ b/events/navigationEvents.js
@@ -1,6 +1,7 @@
 import { signOut } from '../utils/auth';
 import getVocab from '../api/vocabData';
 import showVocabCards from '../pages/vocab';
+import entryForm from '../components/forms/entryForm';
 
 const navigationEvents = (user) => {
   document.querySelector('#app').addEventListener('click', (e) => {
@@ -13,7 +14,7 @@ const navigationEvents = (user) => {
     }
 
     if (e.target.id === 'create-entry') {
-      console.warn('CREATE ENTRY?');
+      entryForm();
     }
   });
 };

--- a/events/navigationEvents.js
+++ b/events/navigationEvents.js
@@ -11,6 +11,10 @@ const navigationEvents = (user) => {
     if (e.target.id === 'home') {
       getVocab(user).then(showVocabCards);
     }
+
+    if (e.target.id === 'create-entry') {
+      console.warn('CREATE ENTRY?');
+    }
   });
 };
 

--- a/styles/main.scss
+++ b/styles/main.scss
@@ -1,5 +1,8 @@
 @import "~bootstrap/scss/bootstrap";
 
+* {
+  box-sizing: border-box;
+}
 
 body {
   background-color: #fde4f2;
@@ -57,4 +60,12 @@ body {
   flex-wrap: wrap;
   justify-content: space-between;
   padding: 0.5rem;
+}
+
+// form styling
+#entryForm {
+  display: flex;
+  justify-content: center;
+  align-content: center;
+  width: 100%;
 }

--- a/utils/startApp.js
+++ b/utils/startApp.js
@@ -2,13 +2,15 @@ import domBuilder from '../components/shared/domBuilder';
 import navBar from '../components/shared/navbar';
 import navigationEvents from '../events/navigationEvents';
 import showVocabCards from '../pages/vocab';
-import getVocab from '../api/vocabData';
+import { getVocab } from '../api/vocabData';
+import formEvents from '../events/formEvents';
 
 const startApp = (user) => {
   domBuilder();
   navBar();
   getVocab(user).then(showVocabCards);
   navigationEvents(user);
+  formEvents(user);
 };
 
 export default startApp;


### PR DESCRIPTION
## Description
- Added a form that serves as both the creation and the updating of cards. Very baseline styling.
- Added promises that are responsible for posting new vocab to database and patching/editing pre-existing terms
- Created submission event listeners that handled creating new terms
- Re-render cards after creation of new card.

## Related Issue
#13

## Motivation and Context
This feature is a cornerstone of the CRUD functionality of this application. Creating entries. 

## How Can This Be Tested?
Pull to local branch and start webserver. 
Put in test data into form section after selecting on the middle icon. 
Check FireBase as well as the re-rendered cards to make sure new entry is included. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
